### PR TITLE
Added option to invalidate key

### DIFF
--- a/memorised/decorators.py
+++ b/memorised/decorators.py
@@ -103,8 +103,8 @@ class memorise(object):
                                 parent_name = inspect.getmodule(fn).__name__
                         # Create a unique hash of the function/method call
                         key = "%s%s(%s)" % (parent_name, fn.__name__, ",".join(arg_values_hash))
+                        key = key.encode('utf8') if type(key)==unicode else key
                         key = md5(key).hexdigest()
-
                         if self.mc:
                                 # Try and get the value from memcache
                                 if self.invalidate and self.use_hint:


### PR DESCRIPTION
I added an option to invalidate a key. It is useful mostly after a database update, so that even if the decorator finds the object on cache, it will reload it from the database and update the cache.
