### PR TITLE
Support for dict-like data stores

### DIFF
--- a/memorised/tests.py
+++ b/memorised/tests.py
@@ -128,6 +128,11 @@ def func_nonzero():
         return 1
 
 
+@instrumented_memorise(mc={})
+def func_dict_cache():
+        return 1
+
+
 class TestMemorise(unittest.TestCase):
         def setUp(self):
                 self.mc = memcache.Client(['localhost:11211'], debug=0)
@@ -226,6 +231,17 @@ class TestMemorise(unittest.TestCase):
                 a2 = f()
                 self.assertEqual(f.mem.function_calls, 1)
                 self.assertEqual(a1, a2)
+
+        def test_dict_cache(self):
+                f = func_dict_cache
+                f.mem.reset()
+                dict_cache = f.mem.mc.wrapped_dict
+                dict_cache.clear()
+                a1 = f()
+                a2 = f()
+                self.assertEqual(a1, 1)
+                self.assertEqual(a2, 1)
+                self.assertEqual({f.mem.key(f, (), {}): 1}, dict_cache)
 
 
 def run():


### PR DESCRIPTION
Using `@memorized()` is a simple and effective way to add caching to an application.

But on some applications, we might not want to store our data in memcached.

A few simple examples: Using a plain `{}` cache is good solution if we don't want/need to share the cache between multiple executions, and `shelve`s are a good way to achieve persistent caching.