### PR TITLE
Fixed PEP8 error: "E402 module level import not at top of file"

### DIFF
--- a/memorised/decorators.py
+++ b/memorised/decorators.py
@@ -1,7 +1,4 @@
 """memorised module - container for the memorise python-memcache decorator"""
-__author__ = 'Wes Mason <wes [at] 1stvamp [dot] org>'
-__docformat__ = 'restructuredtext en'
-__version__ = '1.0.1'
 
 from functools import wraps
 from hashlib import md5
@@ -11,6 +8,10 @@ import itertools
 import memcache
 
 from memorised import compat
+
+__author__ = 'Wes Mason <wes [at] 1stvamp [dot] org>'
+__docformat__ = 'restructuredtext en'
+__version__ = '1.0.1'
 
 
 class memorise(object):


### PR DESCRIPTION
PEP8 can be a bit annoying sometimes...