### PR TITLE
removed reference to python3-memcached

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,17 +15,14 @@ except ImportError:
 from memorised import compat
 
 
-# python-memcached does not have a release compatible with Python 3,
-# so use fork: https://github.com/eguven/python3-memcached
-if compat.PY3:
-    install_requires = ('python3-memcached',)
-else:
-    install_requires = ('python-memcached',)
+install_requires = (
+        'python-memcached>=1.58',
+)
 
 
 setup(
         name='memorised',
-        version='1.1.0',
+        version='1.2.0',
         author='Wes Mason',
         author_email='wes@1stvamp.org',
         description='memcache memoization decorators and utils for python',
@@ -34,7 +31,7 @@ setup(
         packages=find_packages(exclude=('ez_setup',)),
         install_requires=install_requires,
         license='BSD',
-        classifiers = [
+        classifiers=[
                 'Programming Language :: Python',
                 'Programming Language :: Python :: 2',
                 'Programming Language :: Python :: 2.6',


### PR DESCRIPTION
### Description

This PR proposes to remove the import for the python3-memcached library. The author of python3-memcached has noted in the README of the repo that it is for deprecation as the original python-memcached library is already python2/3 compatible.

### Summary of Changes

* Removed python3-memcached import
* Bumped version to 1.2.0
